### PR TITLE
Fix the token parameter name for the API

### DIFF
--- a/PhonegapBuildApi.php
+++ b/PhonegapBuildApi.php
@@ -804,7 +804,7 @@ class PhonegapBuildApi
 
         if ($this->token) {
             // if using token - add it to final request url
-            $url .= '?auth_token=' . $this->token;
+            $url .= '?access_token=' . $this->token;
         } else {
             // if usting username and password - pass then as curl option
             curl_setopt($handle, CURLOPT_USERPWD, $this->username . ':' . $this->password);


### PR DESCRIPTION
The PhoneGap build API requires the token to be called "access_token" instead of "auth_token".

http://docs.build.phonegap.com/en_US/developer_api_oauth.md.html
